### PR TITLE
New environment with bidirectional traffic and redundancies

### DIFF
--- a/imp_act/environments/__init__.py
+++ b/imp_act/environments/__init__.py
@@ -14,7 +14,13 @@ def jax_environment_loader(filename):
 
 environment_path = __path__[0]
 
-presets = ["ToyExample-v1", "Montenegro-v1", "Denmark-v1", "Belgium-v1"]
+presets = [
+    "ToyExample-v1",
+    "ToyExample-v2",
+    "Montenegro-v1",
+    "Denmark-v1",
+    "Belgium-v1",
+]
 
 for name in presets:
 

--- a/imp_act/environments/environment_loader.py
+++ b/imp_act/environments/environment_loader.py
@@ -30,7 +30,7 @@ class EnvironmentLoader:
             graph = Graph.Read_GraphML(open(path, "r"))
             graph.vs["id"] = [int(v["id"]) for v in graph.vs]
         elif graph_config["type"] == "list":
-            graph = Graph(directed=True)
+            graph = Graph(directed=graph_config["directed"])
 
             nodes_list = graph_config["nodes"]
             nodes = [n["id"] for n in nodes_list]

--- a/imp_act/environments/environment_loader.py
+++ b/imp_act/environments/environment_loader.py
@@ -30,7 +30,7 @@ class EnvironmentLoader:
             graph = Graph.Read_GraphML(open(path, "r"))
             graph.vs["id"] = [int(v["id"]) for v in graph.vs]
         elif graph_config["type"] == "list":
-            graph = Graph(directed=False)
+            graph = Graph(directed=True)
 
             nodes_list = graph_config["nodes"]
             nodes = [n["id"] for n in nodes_list]

--- a/imp_act/environments/presets/Belgium-v1/Belgium-v1.yaml
+++ b/imp_act/environments/presets/Belgium-v1/Belgium-v1.yaml
@@ -15,6 +15,7 @@ traffic:
 
 topology:
   graph:
+    directed: false
     path: ./graph.graphml
     type: file
   segments:

--- a/imp_act/environments/presets/Denmark-v1/Denmark-v1.yaml
+++ b/imp_act/environments/presets/Denmark-v1/Denmark-v1.yaml
@@ -15,6 +15,7 @@ traffic:
 
 topology:
   graph:
+    directed: false
     path: ./graph.graphml
     type: file
   segments:

--- a/imp_act/environments/presets/Montenegro-v1/Montenegro-v1.yaml
+++ b/imp_act/environments/presets/Montenegro-v1/Montenegro-v1.yaml
@@ -15,6 +15,7 @@ traffic:
 
 topology:
   graph:
+    directed: false
     path: ./graph.graphml
     type: file
   segments:

--- a/imp_act/environments/presets/ToyExample-v1/ToyExample-v1.yaml
+++ b/imp_act/environments/presets/ToyExample-v1/ToyExample-v1.yaml
@@ -30,6 +30,7 @@ traffic:
         volume: 75
 topology:
   graph:
+    directed: false
     type: "list"
     nodes:
       - id: 0

--- a/imp_act/environments/presets/ToyExample-v2/ToyExample-v2.yaml
+++ b/imp_act/environments/presets/ToyExample-v2/ToyExample-v2.yaml
@@ -33,6 +33,7 @@ traffic:
         volume: 30
 topology:
   graph:
+    directed: true
     type: "list"
     nodes:
       - id: 0

--- a/imp_act/environments/presets/ToyExample-v2/ToyExample-v2.yaml
+++ b/imp_act/environments/presets/ToyExample-v2/ToyExample-v2.yaml
@@ -1,0 +1,179 @@
+maintenance:
+  initial_damage_distribution: [0.85, 0.05, 0.05, 0.05 ,0]
+  include:
+      path: "../common/maintenance_defaults.yaml"
+      override: False
+      
+traffic:
+  travel_time_reward_factor: -50000.0
+  traffic_assignment:
+    max_iterations: 15
+    convergence_threshold: 0.01
+    update_weight: 0.1
+  include:
+    path: "../common/traffic_defaults.yaml"
+    override: False
+  trips:
+    type: "list"
+    list:
+      - origin: 0
+        destination: 5
+        volume: 40
+      - origin: 5
+        destination: 0
+        volume: 40
+      - origin: 1
+        destination: 3
+        volume: 20
+      - origin: 4
+        destination: 2
+        volume: 30
+      - origin: 2
+        destination: 5
+        volume: 30
+topology:
+  graph:
+    type: "list"
+    nodes:
+      - id: 0
+        position_x: 0
+        position_y: 0
+      - id: 1
+        position_x: 0
+        position_y: 1
+      - id: 2
+        position_x: 0
+        position_y: 2
+      - id: 3
+        position_x: 1
+        position_y: 2
+      - id: 4
+        position_x: 1
+        position_y: 1
+      - id: 5
+        position_x: 1
+        position_y: 0
+    edges:
+      - id: 0
+        source: 0
+        target: 1
+        distance: 1
+      - id: 1
+        source: 1
+        target: 0
+        distance: 1
+      - id: 2
+        source: 1
+        target: 2
+        distance: 1
+      - id: 3
+        source: 1
+        target: 3
+        distance: 1
+      - id: 4
+        source: 1
+        target: 4
+        distance: 1
+      - id: 5
+        source: 2
+        target: 3
+        distance: 1
+      - id: 6
+        source: 3
+        target: 2
+        distance: 1
+      - id: 7
+        source: 3
+        target: 4
+        distance: 1
+      - id: 8
+        source: 4
+        target: 1
+        distance: 1
+      - id: 9
+        source: 4
+        target: 5
+        distance: 1
+      - id: 10
+        source: 5
+        target: 4
+        distance: 1
+      - id: 11
+        source: 5
+        target: 1
+        distance: 1
+  segments:
+    type: "list"
+    list:
+      - source: 0
+        target: 1
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null
+      - source: 1
+        target: 0
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null
+      - source: 1
+        target: 2
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null
+      - source: 1
+        target: 3
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null
+      - source: 1
+        target: 4
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null
+      - source: 2
+        target: 3
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null
+      - source: 3
+        target: 2
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null
+      - source: 3
+        target: 4
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null
+      - source: 4
+        target: 1
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null
+      - source: 4
+        target: 5
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null
+      - source: 5
+        target: 4
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null
+      - source: 5
+        target: 1
+        capacity: 50
+        travel_time: 1
+        position_x: null
+        position_y: null

--- a/imp_act/environments/print_episode.py
+++ b/imp_act/environments/print_episode.py
@@ -5,8 +5,8 @@ from imp_act import make
 
 def main():
     env = make("ToyExample-v2")
-    env.count_redundancies()
-    env._print_edge_traffic_summary()
+    print(env.get_count_redundancies_summary())
+    print(env.get_edge_traffic_summary())
     env.reset()
     actions = [[1] * len(e["road_segments"].segments) for e in env.graph.es]
     done = False

--- a/imp_act/environments/print_episode.py
+++ b/imp_act/environments/print_episode.py
@@ -4,9 +4,11 @@ from imp_act import make
 
 
 def main():
-    env = make("ToyExample-v1")
+    env = make("ToyExample-v2")
+    env.count_redundancies()
+    env._print_edge_traffic_summary()
     env.reset()
-    actions = [[1, 1] for _ in range(4)]
+    actions = [[1]*len(e["road_segments"].segments) for e in env.graph.es]
     done = False
     timestep = 0
     while not done:

--- a/imp_act/environments/print_episode.py
+++ b/imp_act/environments/print_episode.py
@@ -8,7 +8,7 @@ def main():
     env.count_redundancies()
     env._print_edge_traffic_summary()
     env.reset()
-    actions = [[1]*len(e["road_segments"].segments) for e in env.graph.es]
+    actions = [[1] * len(e["road_segments"].segments) for e in env.graph.es]
     done = False
     timestep = 0
     while not done:

--- a/imp_act/environments/road_env.py
+++ b/imp_act/environments/road_env.py
@@ -363,34 +363,32 @@ class RoadEnvironment:
             for segment in edge["road_segments"].segments:
                 segment.random_generator = self.random_generator
 
-    def count_redundancies(self, verbose: bool = True):
-
+    def get_count_redundancies_summary(self, verbose: bool = True):
         vcount = self.graph.vcount()
 
         # number of paths between each origin-destination pair
         OD_num_paths = np.zeros((vcount, vcount))
         OD_matrix = np.zeros((vcount, vcount))
 
-        print("")  # empty line
-        print("Summary | Network Trips")
-        print("=" * 23)
-        print("")
+        string = ""
 
-        print(f"Total number of trips: {len(self.trips)}\n")
+        string += "Summary | Network Trips\n"
+        string += "=" * 23 + "\n\n"
+
+        string += f"Total number of trips: {len(self.trips)}\n\n"
 
         for (origin, destination, _) in self.trips:
             paths = self.graph.get_all_simple_paths(origin, destination)
 
             if verbose:
-                print(f"O: {origin}, D: {destination} | # paths: {len(paths)}")
+                string += f"O: {origin}, D: {destination} | # paths: {len(paths)}\n"
 
             OD_num_paths[origin, destination] = len(paths)
             OD_matrix[origin, destination] = 1
 
-        print("")  # empty line
-        print("Summary | Network Redundancy")
-        print("=" * 28)
-        print("")
+        string += "\n"
+        string += "Summary | Network Redundancy\n"
+        string += "=" * 28 + "\n\n"
 
         assert (OD_num_paths - OD_matrix >= 0).all(), "Some paths are missing"
 
@@ -409,20 +407,22 @@ class RoadEnvironment:
 
         # print the redundancy count
         for k, v in redundancy_count.items():
-            print(f"{v} trips have {k} redundancies")
+            string += f"{v} trips have {k} redundancies\n"
+        return string
 
-    def _print_edge_traffic_summary(self):
+    def get_edge_traffic_summary(self):
+        string = ""
+        string += "Summary | Edge Traffic\n"
+        string += "=" * 22 + "\n\n"
+        string += f"{'Edge':^5} {'Volume (%)':^15} {'Travel Time':^5}\n"
+        string += "-" * 30 + "\n"
 
-        print("")
-        print("Summary | Edge Traffic")
-        print("=" * 22)
-        print("")
-        print(f"{'Edge':^5} {'Volume (%)':^15} {'Travel Time':^5}")
-        print("-" * 30)
         for edge in self.graph.es:
             id = edge.index
             volume = edge["volume"]
             travel_time = edge["travel_time"]
             capacity = sum([seg.capacity for seg in edge["road_segments"].segments])
             usage = volume / capacity * 100
-            print(f"{id:^5} {int(volume):^5}({usage:^3.1f}%) {travel_time:^15.2f}")
+            string += f"{id:^5} {int(volume):^5}({usage:^3.1f}%) {travel_time:^15.2f}\n"
+
+        return string

--- a/imp_act/environments/road_env.py
+++ b/imp_act/environments/road_env.py
@@ -411,7 +411,6 @@ class RoadEnvironment:
         for k, v in redundancy_count.items():
             print(f"{v} trips have {k} redundancies")
 
-
     def _print_edge_traffic_summary(self):
 
         print("")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,15 @@ def toy_environment_loader():
 
 
 @pytest.fixture
-def toy_environment():
+def toy_environment_1():
     """Create a toy environment loader for testing."""
     return make("ToyExample-v1")
+
+
+@pytest.fixture
+def toy_environment_2():
+    """Create a toy environment loader for testing."""
+    return make("ToyExample-v2")
 
 
 @pytest.fixture

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -5,10 +5,19 @@ import numpy as np
 import pytest
 
 
-def test_observation_keys(toy_environment):
+environment_fixtures = [
+    "toy_environment_1",
+    "toy_environment_2",
+    "small_environment",
+    "medium_environment",
+    "large_environment",
+]
+
+
+def test_observation_keys(toy_environment_1):
     """Test if the observation dictionary has the correct keys in reset and step functions."""
 
-    env = toy_environment
+    env = toy_environment_1
     obs = env.reset()
 
     keys = [
@@ -28,28 +37,12 @@ def test_observation_keys(toy_environment):
         assert key in obs.keys()
 
 
-def test_one_episode(toy_environment):
-    """Test if the environment can run one episode."""
-    env = toy_environment
-
-    obs = env.reset()
-    actions = [[1] * len(e) for e in obs["edge_observations"]]
-    timestep = 0
-    done = False
-
-    while not done:
-        timestep += 1
-        obs, cost, done, info = env.step(actions)
-
-    assert timestep == env.max_timesteps
-
-
 @pytest.mark.parametrize(
     "parameter_fixture",
-    ["small_environment", "medium_environment", "large_environment"],
+    environment_fixtures,
     indirect=True,
 )
-def test_environment(parameter_fixture):
+def test_one_episode(parameter_fixture):
     """Test if the environment can run one episode."""
     env = parameter_fixture
 
@@ -73,9 +66,9 @@ def test_environment(parameter_fixture):
     print("Test Result: ", end="")
 
 
-def test_timing(toy_environment):
+def test_timing(toy_environment_1):
     "Test if the average time per trajectory is below the threshold"
-    env = toy_environment
+    env = toy_environment_1
 
     obs = env.reset()
     actions = [[1] * len(e) for e in obs["edge_observations"]]
@@ -372,7 +365,7 @@ def seeded_episode_rollout(environment, seed, actions):
 
 @pytest.mark.parametrize(
     "parameter_fixture",
-    ["toy_environment", "small_environment", "medium_environment", "large_environment"],
+    environment_fixtures,
     indirect=True,
 )
 def test_only_negative_rewards(parameter_fixture, test_seed_1, random_time_seed):
@@ -396,7 +389,7 @@ FAIL_LIMIT_RATIO = 3
 @pytest.mark.skip(reason="Waiting for final calibration of the environment")
 @pytest.mark.parametrize(
     "parameter_fixture",
-    ["toy_environment", "small_environment", "medium_environment", "large_environment"],
+    environment_fixtures,
     indirect=True,
 )
 def test_segment_volume_to_capacity_ratio_within_resonable_limits(


### PR DESCRIPTION
## Describe your changes
- Allow bidirectional traffic: add option to set graph type to directed
- Add ToyExample-v2 preset with new topology, bidirectional traffic, and trips params.
- Update road_env.py: 
    - Change how graph edge is selected when appending road segments to it.
    - add methods for counting redundancies and printing edge traffic summary.

## Checklist
- [x] all test are passing
- [x] apply precommit 